### PR TITLE
Fix recurring concat error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ test:
     - apt-get install -y curl
     - apt-get install -y git
     - apt-get install -y rsync
-    - apt-get install -y openjdk-8-jdk
+    - apt-get install -y openjdk-11-jdk
     - apt-get -y install maven samtools bcftools parallel libbz2-dev liblzma-dev
     - bash -c "export JAVA_CMD="$(which java)" && cd /usr/bin && (curl -s https://get.nextflow.io | bash) && chmod 755 nextflow"
     - /usr/bin/nextflow -version

--- a/covid19dp_submission/steps/vcf_vertical_concat/run_vcf_vertical_concat_pipeline.py
+++ b/covid19dp_submission/steps/vcf_vertical_concat/run_vcf_vertical_concat_pipeline.py
@@ -17,6 +17,7 @@ import glob
 import inspect
 import math
 import os
+import shutil
 import sys
 
 from .vcf_vertical_concat import vcf_vertical_concat
@@ -153,10 +154,10 @@ def run_vcf_vertical_concat_pipeline(toplevel_vcf_dir, concat_processing_dir, co
                                      bcftools_binary, nextflow_binary, nextflow_config_file, resume):
     vcf_files = sorted(glob.glob(f"{toplevel_vcf_dir}/*.vcf.gz"))
     expected_result_file = get_concat_result_file_name(concat_processing_dir, len(vcf_files), concat_chunk_size)
-    os.makedirs(concat_processing_dir, exist_ok=True)
-    if os.listdir(concat_processing_dir):
-        raise FileExistsError(f"FAIL: Vertical concatenation processing directory: {concat_processing_dir} "
-                              f"already exists. Please delete that directory to re-process.")
+    if os.path.exists(concat_processing_dir):
+        logger.warning(f'Previous concatenation process output will be deleted: {concat_processing_dir}')
+        shutil.rmtree(concat_processing_dir)
+    os.makedirs(concat_processing_dir)
 
     pipeline, concat_result_file = get_multistage_vertical_concat_pipeline(vcf_files, concat_processing_dir,
                                                                            concat_chunk_size, bcftools_binary)

--- a/tests/test_vertical_concat.py
+++ b/tests/test_vertical_concat.py
@@ -70,12 +70,3 @@ class TestVCFVerticalConcat(TestCase):
                                         return_process_output=True)
         self.assertEqual("", diffs.strip())
 
-        # Attempts at re-processing with the processing directory still existing should fail
-        with self.assertRaises(FileExistsError) as process_dir_exists_exception:
-            run_vcf_vertical_concat_pipeline(toplevel_vcf_dir=download_target_dir,
-                                             concat_processing_dir=self.processing_dir,
-                                             concat_chunk_size=2, bcftools_binary="bcftools",
-                                             nextflow_binary="nextflow", nextflow_config_file=None, resume=False)
-        self.assertEqual(process_dir_exists_exception.exception.args[0],
-                         f"FAIL: Vertical concatenation processing directory: {self.processing_dir} "
-                         f"already exists. Please delete that directory to re-process.")


### PR DESCRIPTION
If an error occurs during a concatenation the subsequent run fails when encountering the existing directory