### PR TITLE
EVA - 3121 Ensure all samples are from SARS-COV-2

### DIFF
--- a/bin/ingest_covid19dp_submission.py
+++ b/bin/ingest_covid19dp_submission.py
@@ -28,6 +28,8 @@ def main():
                         help="Number of analyses to download (max = 10000)")
     parser.add_argument("--processed-analyses-file", required=True,
                         help="full path to the file containing all the processed analyses")
+    parser.add_argument("--ignored-analyses-file", required=True,
+                        help="full path to the file containing a list of analyses to skip when processing.")
     parser.add_argument("--app-config-file",
                         help="Full path to the application config file (ex: /path/to/config.yml)", required=True)
     parser.add_argument("--nextflow-config-file",
@@ -39,7 +41,8 @@ def main():
     logging_config.add_stdout_handler()
 
     ingest_covid19dp_submission(args.project, args.project_dir, args.num_analyses,
-                                args.processed_analyses_file, args.app_config_file, args.nextflow_config_file,
+                                args.processed_analyses_file, args.ignored_analyses_file,
+                                args.app_config_file, args.nextflow_config_file,
                                 args.resume_snapshot)
 
 

--- a/bin/ingest_covid19dp_submission.py
+++ b/bin/ingest_covid19dp_submission.py
@@ -30,6 +30,8 @@ def main():
                         help="full path to the file containing all the processed analyses")
     parser.add_argument("--ignored-analyses-file", required=True,
                         help="full path to the file containing a list of analyses to skip when processing.")
+    parser.add_argument("--accepted-taxonomies", required=True, nargs='+', type=int,
+                        help="taxonomy id of the data that should be downloaded from ENA")
     parser.add_argument("--app-config-file",
                         help="Full path to the application config file (ex: /path/to/config.yml)", required=True)
     parser.add_argument("--nextflow-config-file",
@@ -41,7 +43,7 @@ def main():
     logging_config.add_stdout_handler()
 
     ingest_covid19dp_submission(args.project, args.project_dir, args.num_analyses,
-                                args.processed_analyses_file, args.ignored_analyses_file,
+                                args.processed_analyses_file, args.ignored_analyses_file, args.accepted_taxonomies,
                                 args.app_config_file, args.nextflow_config_file,
                                 args.resume_snapshot)
 

--- a/bin/run_ingestion.sh
+++ b/bin/run_ingestion.sh
@@ -12,8 +12,10 @@ then
 fi
 
 tmp_dir=${eva_dir}/scratch
+project=PRJEB45554
+taxonomy=2697049
 software_dir=${eva_dir}/software/covid19dp-submission/production_deployments/
-project_dir=${eva_dir}/data/PRJEB45554
+project_dir=${eva_dir}/data/${project}
 lock_file=${project_dir}/.lock_ingest_covid19dp_submission
 number_to_process=10000
 
@@ -57,6 +59,7 @@ mkdir -p ${processing_dir} ${log_dir} ${public_dir}
 export TMPDIR=${tmp_dir}
 
 ${software_dir}/production/bin/ingest_covid19dp_submission.py \
+  --project ${project} --accepted-taxonomies ${taxonomy} \
   --project-dir ${project_dir} --app-config-file ${software_dir}/app_config.yml \
   --nextflow-config-file ${software_dir}/workflow.config \
   --processed-analyses-file ${project_dir}/processed_analysis.txt \

--- a/bin/run_ingestion.sh
+++ b/bin/run_ingestion.sh
@@ -77,6 +77,7 @@ if [ ${process_exit_status} == 0 ] && [ ${grep_exit_status} == 0 ];
 then
   touch ${processing_dir}/.process_complete
   nb_processed=$(cat ${project_dir}/processed_analysis.txt| wc -l)
+  nb_ignored=$(cat ${project_dir}/ignored_analysis.txt| wc -l)
   cat > ${processing_dir}/email <<- EOF
 From: eva-noreply@ebi.ac.uk
 To: ${email_recipient}
@@ -84,6 +85,7 @@ Subject: COVID19 Data Processing batch ${current_date} completed successfully
 
 Accessioning/Clustering of ${number_to_process} new COVID19 samples started in ${current_date} is now complete.
 The total number of samples processed is ${nb_processed}
+The number of samples ignored is ${nb_ignored}
 EOF
   cat ${processing_dir}/email | sendmail ${email_recipient}
 else

--- a/bin/run_ingestion.sh
+++ b/bin/run_ingestion.sh
@@ -59,7 +59,9 @@ export TMPDIR=${tmp_dir}
 ${software_dir}/production/bin/ingest_covid19dp_submission.py \
   --project-dir ${project_dir} --app-config-file ${software_dir}/app_config.yml \
   --nextflow-config-file ${software_dir}/workflow.config \
-  --processed-analyses-file ${project_dir}/processed_analysis.txt --num-analyses ${number_to_process} \
+  --processed-analyses-file ${project_dir}/processed_analysis.txt \
+  --ignored-analyses-file ${project_dir}/ignored_analysis.txt \
+  --num-analyses ${number_to_process} \
   --resume-snapshot ${current_date} \
   >> ${processing_dir}/ingest_covid19dp.log \
   2>> ${processing_dir}/ingest_covid19dp.err

--- a/bin/run_ingestion_cron.sh
+++ b/bin/run_ingestion_cron.sh
@@ -9,8 +9,9 @@ then
   echo "run_ingestion.sh does not have access to eva_dir variable. Please set it above or populate ~/.covid19dp_processing"
   exit 1
 fi
+project=PRJEB45554
 software_dir=${eva_dir}/software/covid19dp-submission/production_deployments/
-project_dir=${eva_dir}/data/PRJEB45554
+project_dir=${eva_dir}/data/${project}
 lock_file=${project_dir}/.lock_ingest_covid19dp_submission
 
 #Check if the previous process is still running

--- a/covid19dp_submission/download_analyses.py
+++ b/covid19dp_submission/download_analyses.py
@@ -101,8 +101,8 @@ def get_analyses_to_process(project, num_analyses, total_analyses, processed_ana
             analyses_for_processing = analyses_for_processing + unprocessed_analyses
             logger.debug(f"Number of analyses found for processing till now : {len(analyses_for_processing)}")
             offset = offset + limit
-    logger.debug(f"Number of analyses found for processing: {len(analyses_for_processing)}")
-    logger.debug(f"Number of analyses found to be ignored in the future: {len(new_files_to_ignore)}")
+    logger.info(f"Number of analyses found for processing: {len(analyses_for_processing)}")
+    logger.info(f"Number of analyses found to be ignored in the future: {len(new_files_to_ignore)}")
 
     add_to_ignored_file(new_files_to_ignore, ignored_analysis_file)
 

--- a/covid19dp_submission/download_analyses.py
+++ b/covid19dp_submission/download_analyses.py
@@ -77,8 +77,8 @@ def get_analyses_to_process(project, num_analyses, total_analyses, processed_ana
         logger.info(f"Fetching ENA analyses from {offset} to  {offset + limit} (offset={offset}, limit={limit})")
         analyses_from_ena = get_analyses_from_ena(project, offset, limit)
         unprocessed_analyses = filter_out_processed_analyses(analyses_from_ena, analysis_to_skip)
-        add_to_ignored_file([a for a in analyses_from_ena if a.get('tax_id') not in accepted_taxonomies], ignored_analysis_file)
-        analyses_from_ena = [a for a in analyses_from_ena if a.get('tax_id') in accepted_taxonomies]
+        add_to_ignored_file([a for a in analyses_from_ena if int(a.get('tax_id')) not in accepted_taxonomies], ignored_analysis_file)
+        analyses_from_ena = [a for a in analyses_from_ena if int(a.get('tax_id')) in accepted_taxonomies]
         logger.info(
             f"number of analyses already processed in current iteration: {len(analyses_from_ena) - len(unprocessed_analyses)}")
 

--- a/covid19dp_submission/download_analyses.py
+++ b/covid19dp_submission/download_analyses.py
@@ -71,7 +71,7 @@ def total_analyses_in_project(project):
 def get_analyses_to_process(project, num_analyses, total_analyses, processed_analyses_file, ignored_analysis_file, accepted_taxonomies):
     offset = 0
     limit = 100000
-    analysis_to_skip = get_analyses_from_file(processed_analyses_file) + get_analyses_from_file(ignored_analysis_file)
+    analysis_to_skip = get_analyses_from_file(processed_analyses_file).union(get_analyses_from_file(ignored_analysis_file))
     analyses_for_processing = []
     while offset < total_analyses:
         logger.info(f"Fetching ENA analyses from {offset} to  {offset + limit} (offset={offset}, limit={limit})")

--- a/covid19dp_submission/download_analyses.py
+++ b/covid19dp_submission/download_analyses.py
@@ -127,10 +127,11 @@ def filter_out_processed_analyses(analyses_array, processed_analyses):
 
 def add_to_ignored_file(analyses_array, ignored_analysis_file):
     accession_and_ftp = set()
-    with open(ignored_analysis_file, 'r') as open_file:
-        for line in open_file:
-            accession, ftp_path = line.strip().split(',')
-            accession_and_ftp.add((accession, ftp_path))
+    if os.path.exists(ignored_analysis_file):
+        with open(ignored_analysis_file, 'r') as open_file:
+            for line in open_file:
+                accession, ftp_path = line.strip().split(',')
+                accession_and_ftp.add((accession, ftp_path))
     for analysis in analyses_array:
         accession_and_ftp.add((analysis['analysis_accession'], analysis['submitted_ftp']))
     with open(ignored_analysis_file, 'w') as open_file:

--- a/covid19dp_submission/ingest_covid19dp_submission.py
+++ b/covid19dp_submission/ingest_covid19dp_submission.py
@@ -79,8 +79,8 @@ def _get_config(snapshot_name: str, project_dir: str, nextflow_config_file: str,
 
 
 def ingest_covid19dp_submission(project: str, project_dir: str, num_analyses: int, processed_analyses_file: str,
-                                ignored_analyses_file: str, app_config_file: str, nextflow_config_file: str or None,
-                                resume: str or None):
+                                ignored_analyses_file: str, accepted_taxonomies: list, app_config_file: str,
+                                nextflow_config_file: str or None, resume: str or None):
     process_new_snapshot = False
     if resume is None:
         snapshot_name = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
@@ -102,7 +102,7 @@ def ingest_covid19dp_submission(project: str, project_dir: str, num_analyses: in
     list_file = get_analyses_file_list(config['submission']['download_target_dir'])
     if len(list_file) < num_analyses:
         num_analyses = num_analyses - len(list_file)
-        download_analyses(project, num_analyses, processed_analyses_file, ignored_analyses_file,
+        download_analyses(project, num_analyses, processed_analyses_file, ignored_analyses_file, accepted_taxonomies,
                           config['submission']['download_target_dir'], config['executable']['ascp_bin'],
                           config['aspera']['aspera_id_dsa_key'], config.get('download_batch_size', 100))
     else:

--- a/covid19dp_submission/ingest_covid19dp_submission.py
+++ b/covid19dp_submission/ingest_covid19dp_submission.py
@@ -78,8 +78,8 @@ def _get_config(snapshot_name: str, project_dir: str, nextflow_config_file: str,
     return config
 
 
-def ingest_covid19dp_submission(project: str, project_dir: str, num_analyses: int,
-                                processed_analyses_file: str, app_config_file: str, nextflow_config_file: str or None,
+def ingest_covid19dp_submission(project: str, project_dir: str, num_analyses: int, processed_analyses_file: str,
+                                ignored_analyses_file: str, app_config_file: str, nextflow_config_file: str or None,
                                 resume: str or None):
     process_new_snapshot = False
     if resume is None:
@@ -102,8 +102,9 @@ def ingest_covid19dp_submission(project: str, project_dir: str, num_analyses: in
     list_file = get_analyses_file_list(config['submission']['download_target_dir'])
     if len(list_file) < num_analyses:
         num_analyses = num_analyses - len(list_file)
-        download_analyses(project, num_analyses, processed_analyses_file, config['submission']['download_target_dir'],
-                          config['executable']['ascp_bin'], config['aspera']['aspera_id_dsa_key'], config.get('download_batch_size', 100))
+        download_analyses(project, num_analyses, processed_analyses_file, ignored_analyses_file,
+                          config['submission']['download_target_dir'], config['executable']['ascp_bin'],
+                          config['aspera']['aspera_id_dsa_key'], config.get('download_batch_size', 100))
     else:
         logger.info(f'All {num_analyses} analysis have been downloaded already. Skipping.')
     vcf_files_to_be_downloaded = create_download_file_list(config)

--- a/tests/test_download_analyses.py
+++ b/tests/test_download_analyses.py
@@ -30,7 +30,7 @@ class TestDownloadAnalysis(TestCase):
         if ignored_analysis:
             with open(ignored_analysis_file, 'w') as open_file:
                 for a in ignored_analysis:
-                    open_file.write(a + ',')
+                    print(a + ',', file=open_file)
         analyses = get_analyses_to_process(
             project='PRJEB45554', num_analyses=10, total_analyses=100,
             processed_analyses_file=processed_analyses_file, ignored_analysis_file=ignored_analysis_file,
@@ -53,20 +53,24 @@ class TestDownloadAnalysis(TestCase):
     def test_get_analyses_to_process_ignored_filter(self):
         analyses = self._test_get_analyses_to_process(ignored_analysis=['ERZ10000001', 'ERZ10000003', 'ERZ10000004', 'ERZ10000009', 'ERZ10000010'])
         assert [a.get('analysis_accession') for a in analyses] == [
-            'ERZ10000003', 'ERZ10000004', 'ERZ10000009', 'ERZ10000010', 'ERZ10000014',
-            'ERZ10000017', 'ERZ10000018', 'ERZ10000021', 'ERZ10000023', 'ERZ10000025'
+            'ERZ10000014', 'ERZ10000017', 'ERZ10000018', 'ERZ10000021', 'ERZ10000023',
+            'ERZ10000025', 'ERZ10000026', 'ERZ10000028', 'ERZ10000030', 'ERZ10000031'
         ]
 
     def test_add_to_ignored_file(self):
         analysis_to_ignore = [
             {'analysis_accession': 'accession1', 'submitted_ftp': 'ftp.example.com/accession1/vcf_file1.vcf.gz'},
-            {'analysis_accession': 'accession2', 'submitted_ftp': 'ftp.example.com/accession2/vcf_file1.vcf.gz'}
+            {'analysis_accession': 'accession2', 'submitted_ftp': 'ftp.example.com/accession2/vcf_file2.vcf.gz'}
         ]
         ignored_analysis_file = os.path.join(self.toplevel_download_folder, 'analysis_to_ignore.csv')
         add_to_ignored_file(analyses_array=analysis_to_ignore, ignored_analysis_file=ignored_analysis_file)
         with open(ignored_analysis_file) as open_file:
             lines = open_file.readlines()
         assert len(lines) == 2
+        analysis_to_ignore = [
+            {'analysis_accession': 'accession3', 'submitted_ftp': 'ftp.example.com/accession3/vcf_file3.vcf.gz'},
+            {'analysis_accession': 'accession4', 'submitted_ftp': 'ftp.example.com/accession4/vcf_file4.vcf.gz'}
+        ]
         add_to_ignored_file(analyses_array=analysis_to_ignore, ignored_analysis_file=ignored_analysis_file)
         with open(ignored_analysis_file) as open_file:
             lines = open_file.readlines()

--- a/tests/test_download_analyses.py
+++ b/tests/test_download_analyses.py
@@ -19,6 +19,7 @@ class TestDownloadSnapshot(TestCase):
     processed_analyses_file = os.path.join(toplevel_download_folder, 'processed_analyses_file.txt')
     ignored_analyses_file = os.path.join(toplevel_download_folder, 'ignored_analyses_file.txt')
     project = 'PRJEB45554'
+    accepted_taxonomies = 2697049
     num_analyses_to_download = 1
 
     def setUp(self) -> None:
@@ -55,7 +56,8 @@ class TestDownloadSnapshot(TestCase):
         aspera_id_dsa_key = os.environ['ASPERA_ID_DSA']
         download_analyses(project=self.project, num_analyses=self.num_analyses_to_download,
                           processed_analyses_file=self.processed_analyses_file,
-                          ignored_analyses_file=self.ignored_analyses_file,
+                          ignored_analysis_file=self.ignored_analyses_file,
+                          accepted_taxonomies=self.accepted_taxonomies,
                           download_target_dir=self.download_target_dir, ascp=ascp_bin,
                           aspera_id_dsa=aspera_id_dsa_key, batch_size=100)
         vcf_files = glob.glob(f"{self.download_target_dir}/*.vcf") + glob.glob(f"{self.download_target_dir}/*.vcf.gz")

--- a/tests/test_download_analyses.py
+++ b/tests/test_download_analyses.py
@@ -19,7 +19,7 @@ class TestDownloadSnapshot(TestCase):
     processed_analyses_file = os.path.join(toplevel_download_folder, 'processed_analyses_file.txt')
     ignored_analyses_file = os.path.join(toplevel_download_folder, 'ignored_analyses_file.txt')
     project = 'PRJEB45554'
-    accepted_taxonomies = 2697049
+    accepted_taxonomies = [2697049]
     num_analyses_to_download = 1
 
     def setUp(self) -> None:

--- a/tests/test_download_analyses.py
+++ b/tests/test_download_analyses.py
@@ -17,12 +17,15 @@ class TestDownloadSnapshot(TestCase):
     toplevel_download_folder = os.path.join(resources_folder, 'download_analyses')
     download_target_dir = os.path.join(toplevel_download_folder, '30_eva_valid')
     processed_analyses_file = os.path.join(toplevel_download_folder, 'processed_analyses_file.txt')
+    ignored_analyses_file = os.path.join(toplevel_download_folder, 'ignored_analyses_file.txt')
     project = 'PRJEB45554'
     num_analyses_to_download = 1
 
     def setUp(self) -> None:
         shutil.rmtree(self.toplevel_download_folder, ignore_errors=True)
         os.makedirs(self.download_target_dir)
+        with open(self.ignored_analyses_file, 'w'):
+            pass
 
     def tearDown(self) -> None:
         shutil.rmtree(self.toplevel_download_folder, ignore_errors=True)
@@ -52,6 +55,7 @@ class TestDownloadSnapshot(TestCase):
         aspera_id_dsa_key = os.environ['ASPERA_ID_DSA']
         download_analyses(project=self.project, num_analyses=self.num_analyses_to_download,
                           processed_analyses_file=self.processed_analyses_file,
+                          ignored_analyses_file=self.ignored_analyses_file,
                           download_target_dir=self.download_target_dir, ascp=ascp_bin,
                           aspera_id_dsa=aspera_id_dsa_key, batch_size=100)
         vcf_files = glob.glob(f"{self.download_target_dir}/*.vcf") + glob.glob(f"{self.download_target_dir}/*.vcf.gz")

--- a/tests/test_ingest_covid19dp_submission.py
+++ b/tests/test_ingest_covid19dp_submission.py
@@ -18,7 +18,7 @@ class TestIngestCovid19DPSubmission(TestCase):
         super(TestIngestCovid19DPSubmission, self).__init__(*args, **kwargs)
         self.resources_folder = os.path.join(ROOT_DIR, 'tests', 'resources')
         self.project = 'PRJEB45554'
-        self.accepted_taxonomies = 2697049
+        self.accepted_taxonomies = [2697049]
         self.snapshot_name = '2021_07_23_test_snapshot'
         self.num_of_analyses = 1
         self.assembly_report_url = os.path.join(self.resources_folder,

--- a/tests/test_ingest_covid19dp_submission.py
+++ b/tests/test_ingest_covid19dp_submission.py
@@ -18,6 +18,7 @@ class TestIngestCovid19DPSubmission(TestCase):
         super(TestIngestCovid19DPSubmission, self).__init__(*args, **kwargs)
         self.resources_folder = os.path.join(ROOT_DIR, 'tests', 'resources')
         self.project = 'PRJEB45554'
+        self.accepted_taxonomies = 2697049
         self.snapshot_name = '2021_07_23_test_snapshot'
         self.num_of_analyses = 1
         self.assembly_report_url = os.path.join(self.resources_folder,
@@ -33,6 +34,7 @@ class TestIngestCovid19DPSubmission(TestCase):
         os.makedirs(self.processing_folder)
         self.download_target_dir = os.path.join(self.processing_folder, '30_eva_valid', self.snapshot_name)
         self.processed_analyses_file = os.path.join(self.processing_folder, 'processed_analyses_file.txt')
+        self.ignored_analyses_file = os.path.join(self.processing_folder, 'ignored_analyses_file.txt')
         self.accessioning_database_name = "eva_accession"
         self.accessioning_properties_file = os.path.join(self.processing_folder, 'accessioning.properties')
         self.clustering_properties_file = os.path.join(self.processing_folder, 'clustering.properties')
@@ -96,6 +98,8 @@ class TestIngestCovid19DPSubmission(TestCase):
         ingest_covid19dp_submission(project=self.project,
                                     project_dir=self.processing_folder, num_analyses=2,
                                     processed_analyses_file=self.processed_analyses_file,
+                                    ignored_analyses_file=self.ignored_analyses_file,
+                                    accepted_taxonomies=self.accepted_taxonomies,
                                     app_config_file=self.app_config_file,
                                     nextflow_config_file=self.nextflow_config_file, resume=None)
         num_clustered_variants = self.mongo_db[self.accessioning_database_name]['clusteredVariantEntity'] \


### PR DESCRIPTION
This PR add 2 feature to skip specific samples:
 - First all analysis not marked with the SARS-COV-2 taxonomy id will be skipped and stored in a separate `ignored-analyses-file`
 - Any other analysis added to this `ignored-analyses-file` will be skipped regardless of their taxonomy.