### PR TITLE
Fix download analysis via aspera when retry is involved

### DIFF
--- a/covid19dp_submission/download_analyses.py
+++ b/covid19dp_submission/download_analyses.py
@@ -16,6 +16,7 @@ import argparse
 import copy
 import glob
 import os
+import subprocess
 import urllib
 
 import requests
@@ -182,8 +183,10 @@ def download_files_via_aspera(analyses_array, download_target_dir, processed_ana
                 else:
                     logger.error(f'No Aspera path available for analysis {analysis}')
             command = f'{ascp} -i {aspera_id_dsa} -QT -l 300m -P 33001 {" ".join(download_urls)} {download_target_dir}'
-            run_command_with_output(f"Download batch of covid19 data", command)
-
+            try:
+                run_command_with_output(f"Download batch of covid19 data", command)
+            except subprocess.CalledProcessError:
+                logger.error('Aspera download command failed.')
             for analysis in analysis_batch:
                 expected_output_file = os.path.join(download_target_dir, os.path.basename(analysis['submitted_aspera']))
                 if os.path.exists(expected_output_file):

--- a/covid19dp_submission/download_analyses.py
+++ b/covid19dp_submission/download_analyses.py
@@ -43,8 +43,11 @@ def download_analyses(project, num_analyses, processed_analyses_file, ignored_an
     os.makedirs(download_target_dir, exist_ok=True)
     # Sending a shallow copy of the analyses_array because it will be modified during the download to accommodate
     # the retry mechanism
-    vcf_files_downloaded = download_files_via_aspera(copy.copy(analyses_array), download_target_dir,
-                                                     processed_analyses_file, ascp, aspera_id_dsa, batch_size)
+    # Also sending an empty list of VCF actually downloaded to be populated by download_files_via_aspera even when
+    # retry are used
+    vcf_files_downloaded = []
+    download_files_via_aspera(copy.copy(analyses_array), download_target_dir, processed_analyses_file, ascp,
+                              aspera_id_dsa, vcf_files_downloaded, batch_size)
 
     logger.info(f"total number of files downloaded: {len(vcf_files_downloaded)}")
 
@@ -167,8 +170,7 @@ def download_files(analyses_array, download_target_dir, processed_analyses_file)
 
 @retry(exceptions=(UnfinishedBatchError,), logger=logger, tries=4, delay=10, backoff=1.2, jitter=(1, 3))
 def download_files_via_aspera(analyses_array, download_target_dir, processed_analyses_file, ascp, aspera_id_dsa,
-                              batch_size=100):
-    downloaded_files = []
+                              downloaded_files, batch_size=100):
     logger.info(f"total number of files to download: {len(analyses_array)}")
     with open(processed_analyses_file, 'a') as open_file:
         # This copy won't change throughout the iteration
@@ -185,17 +187,16 @@ def download_files_via_aspera(analyses_array, download_target_dir, processed_ana
             for analysis in analysis_batch:
                 expected_output_file = os.path.join(download_target_dir, os.path.basename(analysis['submitted_aspera']))
                 if os.path.exists(expected_output_file):
-                    downloaded_files.append(expected_output_file)
                     open_file.write(f"{analysis['analysis_accession']},{analysis['submitted_ftp']}\n")
-                    # WARNING: This will modify the content of the original analysis array allowing the retry to
-                    # only deal with a subset of files to download.
+                    # WARNING: This will modify the content of the original analysis array and downloaded files
+                    # allowing the retry to only deal with a subset of files to download.
                     analyses_array.remove(analysis)
+                    downloaded_files.append(expected_output_file)
                 else:
                     logger.warn(f"Failed to download {analysis['submitted_aspera']}")
     if len(analyses_array) > 0:
         # Trigger a retry
         raise UnfinishedBatchError(f'There are {len(analyses_array)} vcf files that were not downloaded')
-    return downloaded_files
 
 
 @retry(logger=logger, tries=4, delay=120, backoff=1.2, jitter=(1, 3))


### PR DESCRIPTION
Download_analysis via aspera uses function's side effect to populate the list of downloaded_files